### PR TITLE
end the stream on unsubscribe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ async-graphql = "^5.0.0"
 warp = { version = "^0.3.2", optional = true }
 async-graphql-warp = { version = "^5.0.0", optional = true }
 http = { version = "^0.2.8", optional = true }
+stream-cancel = "0.8.1"
+dashmap = "5.4.0"
+lazy_static = "1.4.0"
 
 [features]
 graphiql = [ "dep:http", "dep:warp", "dep:async-graphql-warp" ]

--- a/packages/urql/index.ts
+++ b/packages/urql/index.ts
@@ -178,9 +178,12 @@ export function subscribe(
   operation: SubscriptionOperation,
   sink: ObserverLike<ExecutionResult>
 ) {
-  let unlisten: () => void = () => {}
-
   const id = Math.floor(Math.random() * 10000000)
+
+  let unlisten: () => void = () => {
+    Promise.resolve().then(() => invoke('plugin:graphql|subscriptions_end', {...operation, id}))
+       .catch(err => console.error(err))
+  }
 
   Promise.resolve()
     .then(async () =>


### PR DESCRIPTION
In case of an endless stream, I noticed that the listener on the page is removed after pausing a subscription but on the rust side the stream keeps going. The effect is you will only data from one subscription but on the rust side it will keep publishing events for the old subscriptions.

Example of endless stream:
```rust
#[Subscription]
impl Subscription {
  async fn hello_world(&self) -> impl Stream<Item = String> {
    info!("rs2js hello_world subscribe");

      let mut value = 0;
      tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(Duration::from_secs(1)))
          .map(move |_| {
              info!(?value, "rs2js hello_world produce");
              value += 1;
              format!("nr: {}", value)
          })

  }
}
```

I think in the case of a websocket transport the stream is ended because the client will send a 'teardown' message on unsubscribe or in case of page reload the websocket connection is closed which somehow also ends the stream at the rust side. 

This pull request solves the case where client unsubscribes (urql pause). 
Not solved is the case where you can reload the page in a tauri app. Client will just start a new subscription and stream of old subscription alse keeps sending items.

Client was implemented with Sveltekit and @urql/svelte
